### PR TITLE
fix(math): direction() must invert project()

### DIFF
--- a/hastings/math/calib.h
+++ b/hastings/math/calib.h
@@ -110,7 +110,11 @@ class Calib {
         pixel = pixel - center_;
         pixel.y /= aspect_ratio_;
 
-        auto pixel_homogenous = distortion_.undistort(pixel) / focal_length_;
+        // Undistort the focal-normalised coordinate, because that is what project() distorted.
+        // Undistorting the raw pixel offset instead makes direction() disagree with project() by a
+        // factor of the focal length: harmless when k1 is 0, since undistort is then the identity,
+        // and NaN otherwise once 1 + 2*k1*|pixel|^2 goes negative at pixel scale.
+        auto pixel_homogenous = distortion_.undistort(pixel / focal_length_);
 
         auto direction_cam_coords = Vec3s({pixel_homogenous.x, pixel_homogenous.y, Scalar(1.0)});
         const auto point_in_world = RollPitchYawRotatePoint(rpy_, direction_cam_coords, true);
@@ -145,8 +149,6 @@ std::ostream& operator<<(std::ostream& stream, const Calib<Scalar>& calib) {
     stream << ", focal length: " << calib.focalLength();
     stream << ", aspect ratio: " << calib.aspectRatio();
     stream << ", k1: " << calib.distortion().k1;
-    stream << ", k2: " << calib.distortion().k2;
-    stream << ", k3: " << calib.distortion().k3;
     stream << "}";
     return stream;
 }

--- a/tests/hastings/math/test_calib.cpp
+++ b/tests/hastings/math/test_calib.cpp
@@ -69,6 +69,40 @@ TEST(Calib, direction) {
     EXPECT_TRUE(near(calib.direction({3000, 3000}), Vec3d({0.5, 0.5, 1.0}), 1e-4));
 }
 
+TEST(Calib, directionInvertsProject) {
+    // Every other test here uses an ideal lens, where undistort is the identity — so none of them
+    // can tell whether direction() undoes what project() did. With a real k1 it did not.
+    using Calib = hastings::Calib<double>;
+    using Vec3d = hastings::Vec3<double>;
+
+    const Vec3d points[] = {Vec3d({-0.4, -0.3, 1.0}), Vec3d({0.0, 0.0, 1.0}), Vec3d({0.45, 0.35, 1.0}),
+                            Vec3d({0.2, -0.45, 1.0})};
+
+    for (const auto k1 : {0.0, -0.27, 0.2}) {
+        // Identity pose, so a camera-space ray with z = 1 is the point it passes through.
+        const auto calib = Calib({0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {1500, 1500}, 3000, 1.0, {k1});
+
+        for (const auto& point : points) {
+            const auto ray = calib.direction(calib.project(point));
+            EXPECT_TRUE(near(ray, point, 1e-4)) << "k1 = " << k1;
+        }
+    }
+}
+
+TEST(Calib, pixelInZDistorted) {
+    using Calib = hastings::Calib<double>;
+    using Vec3d = hastings::Vec3<double>;
+    using hastings::pixelInZ;
+
+    const auto calib = Calib({0.0, 0.0, 3.0}, {4.71238898, 0.0, 0.0}, {1500, 1500}, 3000, 1.0, {-0.27});
+
+    // Project a point on the ground, then ask where that pixel meets the ground again.
+    const auto point = Vec3d({1.5, -6.0, 0.0});
+    const auto found = pixelInZ(calib, calib.project(point), 0.0);
+
+    EXPECT_TRUE(near(found, point, 1e-3));
+}
+
 TEST(Calib, pixelInZ) {
     using Calib = hastings::Calib<double>;
     using Vec2d = hastings::Vec2<double>;


### PR DESCRIPTION
`Calib::project` distorts the **focal-normalised** coordinate:

```cpp
const auto pixel_homogenous = Vec2s({point_in_cam.x, point_in_cam.y}) / point_in_cam.z;
auto pixel = focal_length_ * distortion_.distort(pixel_homogenous);
```

`Calib::direction` undistorted the **raw pixel offset**:

```cpp
auto pixel_homogenous = distortion_.undistort(pixel) / focal_length_;   // before
auto pixel_homogenous = distortion_.undistort(pixel / focal_length_);   // after
```

So the two disagreed by a factor of the focal length, and `direction()` was not the inverse of `project()`.

## Why it went unnoticed

With `k1 = 0`, `undistort` is the identity and the difference vanishes — and every existing test in `test_calib.cpp` uses an ideal lens (`{0.0}`), including `Calib.direction` and `Calib.pixelInZ`.

With a real distortion it is not subtle. `undistort` computes `sqrt(1 + 2*k1*|p|^2)`, and evaluating that at pixel scale rather than normalised scale makes the radical hugely negative:

```
k1 = -0.27, offset = 100 px   ->  1 + 2*k1*|p|^2 = -5425   ->  NaN
```

`direction()` and `pixelInZ()` then return NaN for every pixel, so anything turning an image point back into a world point silently produced nothing. I hit this calibrating a fence-mounted camera whose lens genuinely has `k1 ≈ -0.27`: enabling distortion made every unprojection fail at once.

## The test

`Calib.directionInvertsProject` projects a point, takes the ray back, and checks it is the point — over `k1` of 0, -0.27 and 0.2. `Calib.pixelInZDistorted` does the same through `pixelInZ` on the ground plane. Both **fail on `main` and pass with the fix**:

```
$ g++ -std=c++17 -I. tests/hastings/math/test_calib.cpp -lgtest -lgtest_main
[  FAILED  ] Calib.directionInvertsProject
[  FAILED  ] Calib.pixelInZDistorted
```

## Also

`operator<<` streamed `calib.distortion().k2` and `.k3`, which `RadialDistortion` does not have — so streaming a `Calib` did not compile. Being a template, it only failed when instantiated, which is presumably why it survived. Removed those two lines.